### PR TITLE
Implement docs, scaffold, and validation runbooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+npm-debug.log*
+artifacts/
+.DS_Store

--- a/.specs/adr/0002-run-artifacts-and-scaffold.md
+++ b/.specs/adr/0002-run-artifacts-and-scaffold.md
@@ -1,0 +1,40 @@
+# ADR 0002: Use Ignored Run Artifacts and Script Scaffolds
+
+## Status
+
+Accepted
+
+## Context
+
+Runbook scripts often produce rendered prompts, raw model outputs, summaries, retry notes, and final outputs. Without a shared location, agents may either leave volatile files in script folders or fail to preserve useful debugging evidence.
+
+New `menton/` scripts also need a consistent structure: `main.mjs`, `prompts/`, `assets/`, and `README.md`.
+
+## Decision
+
+Use this volatile output convention:
+
+```text
+artifacts/<script-name>/<run-id>/
+```
+
+Rules:
+
+- `artifacts/` is ignored by git.
+- Commit stable fixtures under `menton/<script-name>/assets/`, not under `artifacts/`.
+- Production-style examples should write at least a small manifest into each run folder.
+- New script folders can be created with `npm run scaffold -- <script-name>`.
+- Scaffold names must be lowercase kebab-case and the scaffolder refuses overwrites.
+
+## Consequences
+
+Benefits:
+
+- Agents have a predictable place for intermediate and final run outputs.
+- Git stays clean after local validation runs.
+- New scripts start from the repository's expected shape.
+
+Costs:
+
+- Scripts need a few lines to create a run folder and manifest.
+- The ignored artifact folder must not be used for important committed examples.

--- a/.specs/adr/README.md
+++ b/.specs/adr/README.md
@@ -1,0 +1,18 @@
+# ADR Index
+
+Architecture Decision Records live in this folder. Use an ADR when a discovery changes project structure, workflow, or a durable technical convention.
+
+## Accepted
+
+- [ADR 0001: Use Markdown Prompt Files for ZX Scripts](0001-prompt-files-for-zx-and-pi.md)
+- [ADR 0002: Use Ignored Run Artifacts and Script Scaffolds](0002-run-artifacts-and-scaffold.md)
+
+## Writing a new ADR
+
+Create `.specs/adr/NNNN-short-title.md` with:
+
+- status,
+- context,
+- decision,
+- consequences,
+- links to related issues or examples.

--- a/.specs/issues/README.md
+++ b/.specs/issues/README.md
@@ -1,0 +1,25 @@
+# Issue Backlog Notes
+
+Use this folder for durable issue notes when GitHub issue text needs a repo-local companion spec.
+
+## Suggested frontmatter
+
+```yaml
+---
+issue: 12
+title: Short issue title
+status: candidate
+related_adrs:
+  - .specs/adr/0001-prompt-files-for-zx-and-pi.md
+---
+```
+
+## Suggested sections
+
+- Context / evidence
+- Proposed implementation
+- Acceptance criteria
+- Verification plan
+- Risks / blockers
+
+Keep GitHub issues as the source of truth for current status. Repo-local issue files are for structured notes that future agents should inspect with the code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,10 @@ Prompt handling is a first-class design concern in this repository.
 - Prefer separate prompt files over large inline string literals.
 - Keep prompts close to the script that uses them.
 - Make prompt files easy to diff and easy to refine independently from code.
+- Use Markdown prompt files with optional frontmatter for required variables:
+  - `required_variables` lists every `{{placeholder}}` the prompt expects.
+  - `npm run validate:prompts` checks `menton/*/prompts/*.md` for missing prompt files and placeholder/frontmatter drift.
+  - Spikes may use the same convention, but the validator is scoped to production-style `menton/` scripts by default.
 - When prompt structure, loading, composition, or templating becomes a recurring pattern, document the chosen approach in an ADR.
 - If a prompt-writing or prompt-chaining lesson is broadly reusable, add it to the `pi-mentor` skill.
 
@@ -87,6 +91,13 @@ Prompt handling is a first-class design concern in this repository.
 - Spikes are allowed to be rough, but they should still be understandable and isolated.
 - If a spike leads to a reusable pattern, promote that learning into `.specs`, an ADR, the `pi-mentor` skill, or the production structure under `menton/`.
 - Do not leave important discoveries trapped in a spike.
+
+## Run Artifacts
+
+- Volatile run outputs belong under `artifacts/<script-name>/<run-id>/`.
+- Use artifact folders for rendered prompts, raw model outputs, summaries, manifests, and retry notes.
+- `artifacts/` is ignored by git; commit stable examples and fixtures under each script's `assets/` folder instead.
+- Production-style examples should write at least a small manifest so a future agent can inspect what happened without guessing.
 
 ## pi-mentor Skill
 
@@ -114,6 +125,12 @@ When something useful is discovered, decide documentation targets like this:
 - `ADR only`: structural or architectural decision.
 - `pi-mentor only`: execution, prompting, decomposition, or scripting lesson.
 - `ADR + pi-mentor`: a durable structural decision with operational consequences for how agents should work.
+
+Short examples:
+
+- `ADR only`: deciding that all volatile run outputs live under `artifacts/<script-name>/<run-id>/` and are ignored by git. Record the durable repository convention in `.specs/adr/`.
+- `pi-mentor only`: learning that a retry prompt should include the previous error, the exact command, and the expected output shape. Add the reusable execution lesson to `skills/pi-mentor/SKILL.md`.
+- `ADR + pi-mentor`: adopting Markdown prompt files with explicit `{{variable}}` placeholders. The file layout belongs in `.specs/adr/`; the practical prompt-writing rule belongs in the skill.
 
 ## Expected Quality Bar
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,124 @@
 # pi-menton
-runbooks using pi + zx to do things done
+
+Runbooks using Pi + ZX to get real work done with simple, inspectable scripts.
+
+## Prerequisites
+
+- Node.js 20+
+- npm / npx
+- `zx` for runbook scripts (`npm install` installs the local dev dependency)
+- Optional: `pi` CLI for scripts that call a model
+
+Check the current machine before a long run:
+
+```bash
+npm run doctor
+```
+
+The doctor does not make network calls or require secrets. Missing `zx` or `pi` is reported as a warning because some validation tasks only need Node.
+
+## Install
+
+```bash
+npm install
+```
+
+## Quickstart: run the prompt-layout spike
+
+The spike documents the first prompt-file layout experiment:
+
+```bash
+npx zx spike/prompt-layout-zx/main.mjs
+```
+
+Expected behavior:
+
+- lists a small set of files,
+- renders `spike/prompt-layout-zx/prompts/pi-system.md`,
+- renders `spike/prompt-layout-zx/prompts/summarize-findings.md`,
+- calls the configured Pi launcher through the PowerShell helper,
+- prints one result block per file.
+
+If `zx`, PowerShell, or `pi` is not available on your machine, run `npm run doctor` and inspect the spike manually instead:
+
+```bash
+node --test
+npm run validate:prompts
+```
+
+## Production runbooks vs spikes
+
+- `spike/` contains experiments. They can be rough and environment-specific, but important lessons should be promoted into specs, ADRs, skills, or `menton/` examples.
+- `menton/<script-name>/` contains production-style runbooks with `main.mjs`, `prompts/`, `assets/`, and a script README.
+
+A polished example lives at:
+
+```bash
+npx zx menton/prompt-layout-example/main.mjs
+```
+
+It does not call Pi. It renders prompts and writes a manifest under `artifacts/prompt-layout-example/<run-id>/` so the artifact convention can be verified locally.
+
+## Prompt file convention
+
+Prompt files use Markdown with minimal optional frontmatter:
+
+```markdown
+---
+required_variables:
+  - file_path
+---
+Summarize {{file_path}}.
+```
+
+Validate prompt placeholders with:
+
+```bash
+npm run validate:prompts
+```
+
+The checker is intentionally small: every `{{placeholder}}` in a `menton/*/prompts/*.md` file must appear in `required_variables`, and every listed variable must be used.
+
+## Scaffold a new runbook
+
+```bash
+npm run scaffold -- repo-summary
+```
+
+The scaffolder creates:
+
+```text
+menton/repo-summary/
+  main.mjs
+  prompts/task.md
+  assets/
+  README.md
+```
+
+It validates lowercase kebab-case names and refuses to overwrite an existing folder. For tests or demos, set `PI_MENTON_SCAFFOLD_ROOT` to a temporary directory.
+
+## Artifacts
+
+Run outputs belong under:
+
+```text
+artifacts/<script-name>/<run-id>/
+```
+
+Use that folder for rendered prompts, raw model output, summaries, manifests, and retry notes. `artifacts/` is ignored by git. Commit stable fixtures under each script's `assets/` folder instead.
+
+## Specs and guidance
+
+- [ADR 0001: Use Markdown Prompt Files for ZX Scripts](.specs/adr/0001-prompt-files-for-zx-and-pi.md)
+- [ADR 0002: Use Ignored Run Artifacts and Script Scaffolds](.specs/adr/0002-run-artifacts-and-scaffold.md)
+- [ADR index](.specs/adr/README.md)
+- [Issue backlog note format](.specs/issues/README.md)
+- [pi-mentor skill](skills/pi-mentor/SKILL.md)
+
+## Test
+
+```bash
+npm test
+npm run validate:prompts
+npm run doctor
+```

--- a/menton/prompt-layout-example/README.md
+++ b/menton/prompt-layout-example/README.md
@@ -1,0 +1,28 @@
+# Prompt Layout Example
+
+## Purpose
+
+This is a production-style version of the prompt-layout spike. It keeps the same readable shape but lives under `menton/`, uses local `prompts/` and `assets/`, and writes a run manifest under `artifacts/`.
+
+The spike remains useful for rough experiments. This folder shows the structure future runbooks should copy when the pattern is ready for reuse.
+
+## Run
+
+```bash
+npx zx menton/prompt-layout-example/main.mjs
+```
+
+If `zx` is already installed globally, this also works:
+
+```bash
+zx menton/prompt-layout-example/main.mjs
+```
+
+## Validation
+
+```bash
+npm run validate:prompts
+node --test
+```
+
+The script writes volatile run outputs to `artifacts/prompt-layout-example/<run-id>/`. That folder is intentionally ignored by git.

--- a/menton/prompt-layout-example/assets/sample-input.md
+++ b/menton/prompt-layout-example/assets/sample-input.md
@@ -1,0 +1,3 @@
+# Sample input
+
+This sample exists so the production-style example can run without calling Pi or external services.

--- a/menton/prompt-layout-example/main.mjs
+++ b/menton/prompt-layout-example/main.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env zx
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { renderPromptFile } from "../../spike/prompt-layout-zx/prompt-loader.mjs";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const scriptName = "prompt-layout-example";
+const runId = new Date().toISOString().replace(/[:.]/g, "-");
+const runDir = join(process.cwd(), "artifacts", scriptName, runId);
+const promptsDir = join(here, "prompts");
+const sampleInput = join(here, "assets", "sample-input.md");
+
+await mkdir(runDir, { recursive: true });
+
+const systemPrompt = await renderPromptFile(promptsDir, "pi-system.md", {
+  tools_list: "Node.js, filesystem reads, and standard shell tools available in the active environment",
+});
+
+const taskPrompt = await renderPromptFile(promptsDir, "summarize-findings.md", {
+  file_path: sampleInput,
+  goal: "Explain the sample input in a way that proves prompt loading and artifact logging work.",
+});
+
+const inputText = await readFile(sampleInput, "utf8");
+const summary = [
+  `- file: ${basename(sampleInput)}`,
+  `- bytes: ${Buffer.byteLength(inputText, "utf8")}`,
+  "- verification: prompt files rendered and this run wrote an artifact manifest",
+].join("\n");
+
+await writeFile(join(runDir, "system-prompt.md"), systemPrompt);
+await writeFile(join(runDir, "task-prompt.md"), taskPrompt);
+await writeFile(join(runDir, "summary.md"), summary);
+await writeFile(join(runDir, "manifest.json"), JSON.stringify({
+  scriptName,
+  runId,
+  prompts: ["prompts/pi-system.md", "prompts/summarize-findings.md"],
+  input: "assets/sample-input.md",
+  outputs: ["system-prompt.md", "task-prompt.md", "summary.md"],
+}, null, 2));
+
+console.log(`Wrote run artifacts to ${runDir}`);
+console.log(summary);

--- a/menton/prompt-layout-example/prompts/pi-system.md
+++ b/menton/prompt-layout-example/prompts/pi-system.md
@@ -1,0 +1,8 @@
+---
+required_variables:
+  - tools_list
+---
+You are a careful runbook assistant.
+
+Use only tools that are actually available: {{tools_list}}.
+Keep answers short, concrete, and easy to verify.

--- a/menton/prompt-layout-example/prompts/summarize-findings.md
+++ b/menton/prompt-layout-example/prompts/summarize-findings.md
@@ -1,0 +1,13 @@
+---
+required_variables:
+  - file_path
+  - goal
+---
+Read the file at `{{file_path}}`.
+
+Goal: {{goal}}
+
+Return at most three short bullets:
+- what the file does,
+- which inputs or tools matter,
+- how a human can verify it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "pi-menton",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pi-menton",
+      "version": "0.1.0",
+      "devDependencies": {
+        "zx": "^8.8.0"
+      }
+    },
+    "node_modules/zx": {
+      "version": "8.8.5",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-8.8.5.tgz",
+      "integrity": "sha512-SNgDF5L0gfN7FwVOdEFguY3orU5AkfFZm9B5YSHog/UDHv+lvmd82ZAsOenOkQixigwH2+yyH198AwNdKhj+RA==",
+      "dev": true,
+      "bin": {
+        "zx": "build/cli.js"
+      },
+      "engines": {
+        "node": ">= 12.17.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pi-menton",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "doctor": "node tools/doctor.mjs",
+    "scaffold": "node tools/scaffold-menton.mjs",
+    "validate:prompts": "node tools/validate-prompts.mjs",
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "zx": "^8.8.0"
+  }
+}

--- a/skills/pi-mentor/SKILL.md
+++ b/skills/pi-mentor/SKILL.md
@@ -79,6 +79,58 @@ Do not bury step-specific details in the system prompt when they belong to the c
 - Prefer deterministic tool steps before or after Pi when they reduce ambiguity.
 - Keep data transformations inspectable.
 - Preserve useful intermediate outputs when they help retries, debugging, or auditing.
+- Write rendered prompts, raw model output, final output, and a small manifest under `artifacts/<script-name>/<run-id>/` when the run has multiple stages or may need retry/debugging.
+
+## Concrete examples
+
+### Decompose broad work into inspectable stages
+
+Before:
+
+```text
+Read this repository and tell me what to improve.
+```
+
+After:
+
+```text
+Stage 1: list candidate files with `fd` or `find` and save the list.
+Stage 2: ask Pi to summarize only those files into `artifacts/<script>/<run>/raw-summary.md`.
+Stage 3: ask Pi to turn that summary into three prioritized actions.
+Stage 4: validate each action with deterministic commands before editing.
+```
+
+Why it helps: weaker models get a smaller prompt at each step, and humans can inspect the intermediate file list and raw summary before trusting the final recommendation.
+
+### Make retry prompts carry the failed boundary
+
+Before:
+
+```text
+Try again, the command failed.
+```
+
+After:
+
+```text
+The command failed:
+
+command: npm run validate:prompts
+exit: 1
+stderr: FAIL prompt-layout-example/task.md: {{input}} is not listed in required_variables
+
+Fix only the prompt metadata or placeholder text needed to make the validator pass. Do not rewrite the script.
+```
+
+Why it helps: the retry prompt includes the exact failed command, the useful error, and a narrow repair scope.
+
+### Split prompt text from code when it hides the runbook
+
+Before: a `main.mjs` file contains a 100-line inline system prompt followed by two short commands.
+
+After: `main.mjs` shows the command sequence and loads `prompts/system.md` plus `prompts/review.md` with explicit variables.
+
+Why it helps: the script stays readable like a shell runbook, while prompt edits remain easy to diff and validate.
 
 ## Prefer shallow patterns
 

--- a/test/prompt-loader.test.mjs
+++ b/test/prompt-loader.test.mjs
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { renderPromptFile } from "../spike/prompt-layout-zx/prompt-loader.mjs";
+
+test("renderPromptFile loads a prompt and substitutes placeholders", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-menton-prompts-"));
+  await writeFile(join(dir, "task.md"), "Hello {{ name }} from {{place}}\n");
+
+  const rendered = await renderPromptFile(dir, "task.md", { name: "Pi", place: "ZX" });
+
+  assert.equal(rendered, "Hello Pi from ZX");
+});
+
+test("renderPromptFile reports missing variables with useful names", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-menton-prompts-"));
+  await writeFile(join(dir, "task.md"), "Hello {{missing_name}}\n");
+
+  await assert.rejects(
+    renderPromptFile(dir, "task.md", {}),
+    /Missing prompt variable: missing_name/,
+  );
+});
+
+test("renderPromptFile reports missing files", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-menton-prompts-"));
+
+  await assert.rejects(
+    renderPromptFile(dir, "missing.md", {}),
+    /ENOENT.*missing\.md/,
+  );
+});

--- a/tools/doctor.mjs
+++ b/tools/doctor.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+
+let failures = 0;
+
+function check(label, command, args = [], options = {}) {
+  const result = spawnSync(command, args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  const status = result.status === 0 ? "PASS" : options.warn ? "WARN" : "FAIL";
+  if (status === "FAIL") failures += 1;
+  const detail = result.status === 0
+    ? (result.stdout || result.stderr).trim().split("\n")[0]
+    : options.message || (result.stderr || result.stdout || result.error?.message || "not available").trim().split("\n")[0];
+  console.log(`${status} ${label}${detail ? ` - ${detail}` : ""}`);
+}
+
+check("Node", "node", ["--version"]);
+check("npm", "npm", ["--version"], { warn: true });
+check("npx", "npx", ["--version"], { warn: true });
+check("zx", "zx", ["--version"], { warn: true, message: "install dependencies with npm install, or use npx zx" });
+check("pi", process.env.PI_MENTON_PI_COMMAND || "pi", ["--help"], { warn: true, message: "optional; set PI_MENTON_PI_COMMAND if your Pi launcher has a different name" });
+
+console.log(process.env.PI_MENTON_MODEL ? `PASS PI_MENTON_MODEL - ${process.env.PI_MENTON_MODEL}` : "WARN PI_MENTON_MODEL - unset; examples use documented defaults when possible");
+
+if (failures > 0) process.exit(1);

--- a/tools/prompt-metadata.mjs
+++ b/tools/prompt-metadata.mjs
@@ -1,0 +1,37 @@
+import { readFile } from "node:fs/promises";
+
+export function parsePromptMetadata(text) {
+  if (!text.startsWith("---\n")) return { metadata: {}, body: text };
+  const end = text.indexOf("\n---", 4);
+  if (end === -1) return { metadata: {}, body: text };
+
+  const raw = text.slice(4, end).trimEnd();
+  const body = text.slice(end + 5).replace(/^\n/, "");
+  const metadata = {};
+  let currentKey = null;
+
+  for (const line of raw.split("\n")) {
+    const keyMatch = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (keyMatch) {
+      currentKey = keyMatch[1];
+      const value = keyMatch[2];
+      metadata[currentKey] = value ? value : [];
+      continue;
+    }
+    const listMatch = line.match(/^\s*-\s+(.+)$/);
+    if (listMatch && currentKey) {
+      if (!Array.isArray(metadata[currentKey])) metadata[currentKey] = [];
+      metadata[currentKey].push(listMatch[1].trim());
+    }
+  }
+
+  return { metadata, body };
+}
+
+export function placeholdersIn(text) {
+  return [...text.matchAll(/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g)].map((match) => match[1]);
+}
+
+export async function readPromptFileWithMetadata(path) {
+  return parsePromptMetadata(await readFile(path, "utf8"));
+}

--- a/tools/scaffold-menton.mjs
+++ b/tools/scaffold-menton.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const name = process.argv[2];
+const root = process.env.PI_MENTON_SCAFFOLD_ROOT || process.cwd();
+
+if (!name || !/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(name)) {
+  console.error("Usage: npm run scaffold -- <script-name>");
+  console.error("Names must be lowercase kebab-case, for example: repo-summary");
+  process.exit(1);
+}
+
+const dir = join(root, "menton", name);
+if (existsSync(dir)) {
+  console.error(`Refusing to overwrite existing script folder: ${dir}`);
+  process.exit(1);
+}
+
+await mkdir(join(dir, "prompts"), { recursive: true });
+await mkdir(join(dir, "assets"), { recursive: true });
+
+await writeFile(join(dir, "main.mjs"), `#!/usr/bin/env zx\n\nimport { mkdir, writeFile } from "node:fs/promises";\nimport { join } from "node:path";\n\nconst scriptName = "${name}";\nconst runId = new Date().toISOString().replace(/[:.]/g, "-");\nconst runDir = join(process.cwd(), "artifacts", scriptName, runId);\n\nawait mkdir(runDir, { recursive: true });\nawait writeFile(join(runDir, "manifest.json"), JSON.stringify({ scriptName, runId, status: "created" }, null, 2));\n\nconsole.log(\`Created run artifact folder: \${runDir}\`);\n`);
+
+await writeFile(join(dir, "prompts", "task.md"), `---\nrequired_variables:\n  - input\n---\nProcess this input:\n\n{{input}}\n`);
+await writeFile(join(dir, "assets", ".gitkeep"), "");
+await writeFile(join(dir, "README.md"), `# ${name}\n\n## Purpose\n\nDescribe what this runbook does and when to use it.\n\n## Run\n\n\`\`\`bash\nnpx zx menton/${name}/main.mjs\n\`\`\`\n\n## Validation\n\n\`\`\`bash\nnpm run validate:prompts -- menton/${name}\n\`\`\`\n\nGenerated run outputs belong under \`artifacts/${name}/<run-id>/\` and are ignored by git.\n`);
+
+console.log(`Created menton/${name}`);

--- a/tools/validate-prompts.mjs
+++ b/tools/validate-prompts.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+import { readdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
+import { placeholdersIn, readPromptFileWithMetadata } from "./prompt-metadata.mjs";
+
+const root = process.cwd();
+const target = process.argv[2];
+const mentonDir = join(root, "menton");
+let failures = 0;
+
+function fail(message) {
+  failures += 1;
+  console.error(`FAIL ${message}`);
+}
+
+async function scriptDirs() {
+  if (target) return [isAbsolute(target) ? target : resolve(root, target)];
+  if (!existsSync(mentonDir)) return [];
+  const entries = await readdir(mentonDir, { withFileTypes: true });
+  return entries.filter((entry) => entry.isDirectory()).map((entry) => join(mentonDir, entry.name));
+}
+
+for (const dir of await scriptDirs()) {
+  const name = dir.split("/").pop();
+  const promptsDir = join(dir, "prompts");
+  if (!existsSync(promptsDir)) {
+    fail(`${name}: missing prompts/ directory`);
+    continue;
+  }
+
+  const prompts = (await readdir(promptsDir, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"));
+
+  if (prompts.length === 0) fail(`${name}: prompts/ has no Markdown prompt files`);
+
+  for (const prompt of prompts) {
+    const promptPath = join(promptsDir, prompt.name);
+    const { metadata, body } = await readPromptFileWithMetadata(promptPath);
+    const placeholders = [...new Set(placeholdersIn(body))];
+    const required = Array.isArray(metadata.required_variables) ? metadata.required_variables : [];
+
+    if (placeholders.length > 0 && required.length === 0) {
+      fail(`${name}/${prompt.name}: placeholders exist but required_variables frontmatter is missing`);
+    }
+
+    for (const placeholder of placeholders) {
+      if (!required.includes(placeholder)) {
+        fail(`${name}/${prompt.name}: {{${placeholder}}} is not listed in required_variables`);
+      }
+    }
+
+    for (const variable of required) {
+      if (!placeholders.includes(variable)) {
+        fail(`${name}/${prompt.name}: required variable ${variable} is not used in the prompt body`);
+      }
+    }
+  }
+}
+
+if (failures > 0) {
+  console.error(`\nPrompt validation failed with ${failures} problem(s).`);
+  process.exit(1);
+}
+
+console.log("PASS prompt files are present and placeholder metadata matches.");


### PR DESCRIPTION
## Summary

Implements the approved pi-menton follow-up set (#2-#11) as one coherent docs/scaffold/tooling PR:

- expands the root quickstart and documents spike vs production runbooks
- adds `menton/prompt-layout-example/` promoted from the prompt-layout spike
- adds prompt placeholder metadata convention plus `npm run validate:prompts`
- adds pi-mentor examples for decomposition, retries, and prompt/code splits
- adds ADR and issue backlog indexes
- adds `npm run doctor` for local tool assumptions
- documents/implements ignored run artifact folders with example manifests
- adds Node tests for the spike prompt loader
- adds `npm run scaffold -- <script-name>` for new `menton/` runbooks

## Issues covered

Closes #2
Closes #3
Closes #4
Closes #5
Closes #6
Closes #7
Closes #8
Closes #9
Closes #10
Closes #11

## Verification

```bash
npm install
npm test
npm run validate:prompts
npm run doctor
npx zx menton/prompt-layout-example/main.mjs
TMPDIR=$(mktemp -d)
PI_MENTON_SCAFFOLD_ROOT="$TMPDIR" npm run scaffold -- demo-runbook
npm run validate:prompts -- "$TMPDIR/menton/demo-runbook"
PI_MENTON_SCAFFOLD_ROOT="$TMPDIR" npm run scaffold -- demo-runbook # expected overwrite refusal
# malformed temp prompt fixture was also checked and failed validation as expected
```

Doctor output in this environment reports `PI_MENTON_MODEL` as unset warning only; no secret or network check is required.
